### PR TITLE
chore: bump version to 0.1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "ccost"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccost"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary

- Bump patch version from 0.1.11 to 0.1.12