### PR TITLE
Bump version to 0.1.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "ccost"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccost"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Bump ccost to 0.1.15
- Update Cargo.lock package version

## Testing
- cargo build
- cargo test
- cargo clippy -- -D warnings
- cargo fmt --check