### PR TITLE
Bump version to 0.1.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "ccost"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccost"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary

- bump ccost from 0.1.21 to 0.1.22
- refresh Cargo.lock

## Testing

- cargo build
- cargo test -- --test-threads=1
- cargo clippy -- -D warnings
- cargo fmt --check
- git diff --check